### PR TITLE
Add cancel and uncancel methods to Event class

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ public void onListenYourFavoriteEvent(YourFavoriteEvent event) {
 ## Future Plans 🛌
 
 - [ ] Asynchronous events
-- [ ] Event cancellation
+- [x] Event cancellation
 - [x] Event listener registration
 - [ ] Event listener deregistration
 - [ ] Event listener priority

--- a/src/main/java/at/jkvn/eventlib/Event.java
+++ b/src/main/java/at/jkvn/eventlib/Event.java
@@ -3,8 +3,15 @@ package at.jkvn.eventlib;
 import lombok.Getter;
 import lombok.Setter;
 
-@Setter
 @Getter
 public abstract class Event {
     private boolean cancelled = false;
+
+    public void cancel() {
+        this.cancelled = true;
+    }
+
+    public void uncancel() {
+        this.cancelled = false;
+    }
 }


### PR DESCRIPTION
The Event class now includes 'cancel' and 'uncancel' methods to allow events to be cancelled and uncancelled. The README.md file has been updated to reflect this addition, marking the task of "Event cancellation" as completed.